### PR TITLE
[#1119] api security check: requests all allow when security policy not set

### DIFF
--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessController.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessController.java
@@ -49,6 +49,7 @@ public class SecurityPolicyAccessController implements AccessController {
     if (StringUtils.isEmpty(currentServiceName)) {
       currentServiceName = authenticationAdapter.getServiceName(extractor.serviceId());
     }
+    // mode is null, see not set policy, all request allow.
     if (StringUtils.isEmpty(securityPolicyProperties.getMode())) {
       return true;
     }

--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessController.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessController.java
@@ -14,7 +14,7 @@
  */
 package com.huaweicloud.governance.authentication.securityPolicy;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +48,9 @@ public class SecurityPolicyAccessController implements AccessController {
     }
     if (StringUtils.isEmpty(currentServiceName)) {
       currentServiceName = authenticationAdapter.getServiceName(extractor.serviceId());
+    }
+    if (StringUtils.isEmpty(securityPolicyProperties.getMode())) {
+      return true;
     }
     return checkAllowAndDeny(currentServiceName, extractor);
   }

--- a/spring-cloud-huawei-governance/src/test/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessControllerTest.java
+++ b/spring-cloud-huawei-governance/src/test/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessControllerTest.java
@@ -551,6 +551,19 @@ public class SecurityPolicyAccessControllerTest {
         .isAllowed(extractor));
   }
 
+  @Test
+  public void testPolicyIsNull() throws Exception {
+    AuthRequestExtractor extractor = createAuthRequestExtractor("/checkTokenPer/security/checkTokenSfu");
+    Assertions.assertTrue(getNoSettingAccessController()
+        .isAllowed(extractor));
+  }
+
+  private SecurityPolicyAccessController getNoSettingAccessController() {
+    securityPolicyProperties.setAction(null);
+    securityPolicyProperties.setMode(null);
+    return new SecurityPolicyAccessController(authenticationAdapter, securityPolicyProperties);
+  }
+
   private SecurityPolicyAccessController getAllowAccessController(String mode) {
     Action action = new Action();
     action.setAllow(buildAllow());


### PR DESCRIPTION
pr_rerun QDinsight:2021.0.x-security to 2021.0.x